### PR TITLE
Split HTTP client and Pixiv primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,18 @@ authors = ["Allen Bui <allenbui94@gmail.com>"]
 license = "MIT"
 
 [dependencies]
-reqwest = "0.9"
+reqwest = { version = "0.9", optional = true }
+bytes = "0.4"
 http = "0.1"
 serde = "1"
 serde_json = "1.0.11"
+serde_urlencoded = "0.5"
 chrono = "0.4"
 log = "0.3"
 
 [dev-dependencies]
 kankyo = "~0.2"
+
+[features]
+default = ["reqwest-client"]
+reqwest-client = ["reqwest"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,305 @@
+use ::std::collections::HashMap;
+
+use ::reqwest;
+use ::reqwest::{Response, Client};
+use ::http::status::StatusCode;
+use ::serde_json::Value;
+
+use super::{AuthError, PixivRequest};
+
+// This is taken from the Android app, don't worry about it. It's not really "compromisable", to some degree.
+const CLIENT_ID: &str = "MOBrBDS8blbauoSck0ZfDbtuzpyT";
+const CLIENT_SECRET: &str = "lsACyCD94FhDUtGTXi3QzcFE2uU1hqtDaKeqrdwj";
+
+/// Used to authenticate to the Pixiv servers and construct Pixiv requests through methods creating `PixivRequestBuilder`.
+#[derive(Debug, Clone)]
+pub struct Pixiv {
+    client: Client,
+    access_token: String,
+    refresh_token: String,
+}
+
+impl Pixiv {
+    /// Creates a new Pixiv struct.
+    #[inline]
+    pub fn new(client: &Client) -> Pixiv {
+        Pixiv {
+            client: client.clone(),
+            access_token: String::default(),
+            refresh_token: String::default(),
+        }
+    }
+    /// This is required to use all the other functions this library provides. Requires a valid username and password.
+    pub fn login(&mut self, username: &str, password: &str) -> Result<(), AuthError> {
+        let mut data = HashMap::new();
+
+        data.insert("client_id", CLIENT_ID);
+        data.insert("client_secret", CLIENT_SECRET);
+        data.insert("get_secure_url", "1");
+
+        data.insert("grant_type", "password");
+        data.insert("username", username);
+        data.insert("password", password);
+
+        let mut res = self.send_auth_request(&data)
+            .expect("Error occured while requesting token.");
+
+        match res.status() {
+            StatusCode::OK | StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND => {
+                // success
+            }
+            s => {
+                return Err(AuthError {
+                    reason: format!(
+                        "Login failed. Check your username and password. Response: {:?}",
+                        s
+                    ),
+                })
+            }
+        }
+
+        let mut json_response: Value = res.json().unwrap();
+
+        self.access_token = match json_response["response"]["access_token"].take() {
+            Value::String(s) => s,
+            _ => panic!("Failed to get access token."),
+        };
+        self.refresh_token = match json_response["response"]["refresh_token"].take() {
+            Value::String(s) => s,
+            _ => panic!("Failed to get refresh token."),
+        };
+        Ok(())
+    }
+    /// Refreshes the authentication. You should use this when your access token is close to expiring.
+    pub fn refresh_auth(&mut self) -> Result<(), AuthError> {
+        let refresh_clone = self.refresh_token.clone();
+        let mut data = HashMap::new();
+
+        data.insert("client_id", CLIENT_ID);
+        data.insert("client_secret", CLIENT_SECRET);
+        data.insert("get_secure_url", "1");
+
+        data.insert("grant_type", "refresh_token");
+        data.insert("refresh_token", refresh_clone.as_str());
+
+        let mut res = self.send_auth_request(&data)
+            .expect("Error occured while requesting token.");
+
+        match res.status() {
+            StatusCode::OK | StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND => {
+                // success
+            }
+            s => {
+                return Err(AuthError {
+                    reason: format!("Login failed. Check your refresh token. Response: {:?}", s),
+                })
+            }
+        }
+
+        let mut json_response: Value = res.json().unwrap();
+
+        self.access_token = match json_response["response"]["access_token"].take() {
+            Value::String(s) => s,
+            _ => panic!("Failed to get access token."),
+        };
+        self.refresh_token = match json_response["response"]["refresh_token"].take() {
+            Value::String(s) => s,
+            _ => panic!("Failed to get refresh token."),
+        };
+        Ok(())
+    }
+    /// Get the access token.
+    #[inline]
+    pub fn access_token(&self) -> &String {
+        &self.access_token
+    }
+    /// Get a mutable reference to the access token.
+    #[inline]
+    pub fn access_token_mut(&mut self) -> &mut String {
+        &mut self.access_token
+    }
+    /// Get the refresh token.
+    #[inline]
+    pub fn refresh_token(&self) -> &String {
+        &self.refresh_token
+    }
+    /// Get a mutable reference to the refresh token.
+    #[inline]
+    pub fn refresh_token_mut(&mut self) -> &mut String {
+        &mut self.refresh_token
+    }
+
+    // private helper method
+    fn send_auth_request(&self, data: &HashMap<&str, &str>) -> Result<Response, reqwest::Error> {
+        self.client
+            .post("https://oauth.secure.pixiv.net/auth/token")
+            .form(&data)
+            .send()
+    }
+
+    /// Executes a given `PixivRequest`.
+    pub fn execute(&self, request: PixivRequest) -> Result<Response, reqwest::Error> {
+        let uri = format!("{}", request.url);
+        let url = reqwest::Url::parse(&uri).unwrap();
+        self.client.request(request.method,  url)
+                   .headers(request.headers)
+                   .bearer_auth(self.access_token.clone())
+                   .send()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ::reqwest::Client;
+    use ::serde_json::Value;
+    use super::Pixiv;
+
+    use super::super::*;
+
+    #[test]
+    fn test_login() {
+        let client = Client::new();
+
+        let mut pixiv: Pixiv = Pixiv::new(&client);
+
+        kankyo::load().unwrap();
+
+        pixiv
+            .login(
+                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
+                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
+            )
+            .expect("Failed to log in.");
+    }
+
+    #[test]
+    fn test_refresh_auth() {
+        let client = Client::new();
+
+        let mut pixiv: Pixiv = Pixiv::new(&client);
+
+        kankyo::load().unwrap();
+
+        pixiv
+            .login(
+                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
+                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
+            )
+            .expect("Failed to log in.");
+
+        pixiv
+            .refresh_auth()
+            .expect("Failed to refresh access token");
+    }
+
+    #[test]
+    fn test_bad_words() {
+        let client = Client::new();
+
+        let mut pixiv: Pixiv = Pixiv::new(&client);
+
+        kankyo::load().unwrap();
+
+        pixiv
+            .login(
+                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
+                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
+            )
+            .expect("Failed to log in.");
+
+        let request = PixivRequestBuilder::bad_words().build();
+        let bad_words: Value = pixiv.execute(request)
+            .expect("Request failed.")
+            .json()
+            .expect("Failed to parse as json.");
+
+        println!("{}", bad_words);
+    }
+
+    #[test]
+    fn test_work() {
+        let client = Client::new();
+
+        let mut pixiv: Pixiv = Pixiv::new(&client);
+
+        kankyo::load().unwrap();
+
+        pixiv
+            .login(
+                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
+                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
+            )
+            .expect("Failed to log in.");
+
+        let request = PixivRequestBuilder::work(66024340).build();
+        let work: Value = pixiv.execute(request)
+            .expect("Request failed.")
+            .json()
+            .expect("Failed to parse as json.");
+
+        println!("{}", work);
+    }
+
+    #[test]
+    fn test_user() {
+        let client = Client::new();
+
+        let mut pixiv: Pixiv = Pixiv::new(&client);
+
+        kankyo::load().unwrap();
+
+        pixiv
+            .login(
+                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
+                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
+            )
+            .expect("Failed to log in.");
+
+        let request = PixivRequestBuilder::user(6996493).build();
+        let following_works: Value = pixiv
+            .execute(request)
+            .expect("Request failed.")
+            .json()
+            .expect("Failed to parse as json.");
+
+        println!("{}", following_works);
+    }
+
+    #[test]
+    fn test_following_works() {
+        let client = Client::new();
+
+        let mut pixiv: Pixiv = Pixiv::new(&client);
+
+        kankyo::load().unwrap();
+
+        pixiv
+            .login(
+                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
+                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
+            )
+            .expect("Failed to log in.");
+
+        let request = PixivRequestBuilder::following_works()
+            .image_sizes(&["large"])
+            .include_sanity_level(false)
+            .build();
+        let following_works: Value = pixiv
+            .execute(request)
+            .expect("Request failed.")
+            .json()
+            .expect("Failed to parse as json.");
+
+        println!("{}", following_works);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_login_fail() {
+        let client = Client::new();
+
+        let mut pixiv: Pixiv = Pixiv::new(&client);
+
+        pixiv.login("", "").expect("Failed to log in.");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! ```rust,no_run
 //! # extern crate pixiv;
 //! # extern crate reqwest;
-//! # use pixiv::Pixiv;
+//! # use pixiv::client::Pixiv;
 //! # use reqwest::Client;
 //! # fn main() {
 //!     let client = Client::new();
@@ -28,7 +28,7 @@
 //! ```rust,no_run
 //! # extern crate pixiv;
 //! # extern crate reqwest;
-//! # use pixiv::Pixiv;
+//! # use pixiv::client::Pixiv;
 //! # use reqwest::Client;
 //! # fn main() {
 //!     let client = Client::new();
@@ -50,16 +50,17 @@
 //! # extern crate pixiv;
 //! # extern crate reqwest;
 //! # extern crate serde_json;
-//! # use pixiv::Pixiv;
+//! # use pixiv::client::Pixiv;
+//! # use pixiv::PixivRequestBuilder;
 //! # use reqwest::Client;
 //! # use serde_json::Value;
 //! # fn main() {
 //! #   let client = Client::new();
 //! #   let mut pixiv: Pixiv = Pixiv::new(&client);
 //! #   pixiv.login("username", "password");
+//!     let request = PixivRequestBuilder::work(66024340).build();
 //!     let work: Value = pixiv
-//!         .work(66024340)
-//!         .send()
+//!         .execute(request)
 //!         .expect("Request failed.")
 //!         .json()
 //!         .expect("Failed to parse as json.");
@@ -72,18 +73,20 @@
 //! # extern crate pixiv;
 //! # extern crate reqwest;
 //! # extern crate serde_json;
-//! # use pixiv::Pixiv;
+//! # use pixiv::client::Pixiv;
+//! # use pixiv::PixivRequestBuilder;
 //! # use reqwest::Client;
 //! # use serde_json::Value;
 //! # fn main() {
 //! #   let client = Client::new();
 //! #   let mut pixiv: Pixiv = Pixiv::new(&client);
 //! #   pixiv.login("username", "password");
-//!     let following_works: Value = pixiv
-//!        .following_works()
+//!     let request = PixivRequestBuilder::following_works()
 //!        .image_sizes(&["large"])
 //!        .include_sanity_level(false)
-//!        .send()
+//!        .build();
+//!     let following_works: Value = pixiv
+//!        .execute(request)
 //!        .expect("Request failed.")
 //!        .json()
 //!        .expect("Failed to parse as json.");
@@ -101,56 +104,44 @@
 //! * More API support (although pixiv doesn't document their public API anywhere to my knowledge...)
 
 extern crate chrono;
+#[cfg(feature = "reqwest-client")]
 pub extern crate reqwest;
 pub extern crate http;
 extern crate serde;
 extern crate serde_json;
+extern crate serde_urlencoded;
+extern crate bytes;
 
 #[cfg(test)]
 extern crate kankyo;
 
-#[macro_use]
-extern crate log;
-
 use std::borrow::{Borrow, Cow};
 use std::collections::HashMap;
 use std::error::Error;
-use std::fmt::{self, Write};
+use std::fmt;
+use std::io::Write;
 
 use chrono::naive::NaiveDate;
 
-use reqwest::Client;
-use reqwest::Response;
-use http::status::StatusCode;
-pub use http::{header, HeaderMap, Method};
-use reqwest::Url;
+pub use http::{HttpTryFrom, header, HeaderMap, Method, uri::Uri};
 
-use serde_json::Value;
+mod utils;
+#[cfg(feature = "reqwest-client")]
+pub mod client;
 
-// This is taken from the Android app, don't worry about it. It's not really "compromisable", to some degree.
-const CLIENT_ID: &str = "MOBrBDS8blbauoSck0ZfDbtuzpyT";
-const CLIENT_SECRET: &str = "lsACyCD94FhDUtGTXi3QzcFE2uU1hqtDaKeqrdwj";
-
-/// Used to authenticate to the Pixiv servers and construct Pixiv requests through methods creating `PixivRequestBuilder`.
-#[derive(Debug, Clone)]
-pub struct Pixiv {
-    client: Client,
-    access_token: String,
-    refresh_token: String,
-}
+use utils::comma_delimited;
 
 /// Pixiv request. You can create this using `PixivRequestBuilder::build`. This is for if you wish to inspect the request before sending.
 #[derive(Debug, Clone)]
 pub struct PixivRequest {
-    method: Method,
-    url: Url,
-    headers: HeaderMap,
+    pub method: Method,
+    pub url: Uri,
+    pub headers: HeaderMap,
 }
 
 /// Pixiv request builder. You can create this using any of the provided methods in `Pixiv`, or through `PixivRequestBuilder::new`.
 #[derive(Debug, Clone)]
 pub struct PixivRequestBuilder<'a> {
-    pixiv: &'a Pixiv,
     request: PixivRequest,
     params: HashMap<&'a str, Cow<'a, str>>,
 }
@@ -304,503 +295,11 @@ impl SearchOrder {
     }
 }
 
-impl Pixiv {
-    /// Creates a new Pixiv struct.
-    #[inline]
-    pub fn new(client: &Client) -> Pixiv {
-        Pixiv {
-            client: client.clone(),
-            access_token: String::default(),
-            refresh_token: String::default(),
-        }
-    }
-    /// This is required to use all the other functions this library provides. Requires a valid username and password.
-    pub fn login(&mut self, username: &str, password: &str) -> Result<(), AuthError> {
-        let mut data = HashMap::new();
-
-        data.insert("client_id", CLIENT_ID);
-        data.insert("client_secret", CLIENT_SECRET);
-        data.insert("get_secure_url", "1");
-
-        data.insert("grant_type", "password");
-        data.insert("username", username);
-        data.insert("password", password);
-
-        let mut res = self.send_auth_request(&data)
-            .expect("Error occured while requesting token.");
-
-        match res.status() {
-            StatusCode::OK | StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND => {
-                // success
-            }
-            s => {
-                return Err(AuthError {
-                    reason: format!(
-                        "Login failed. Check your username and password. Response: {:?}",
-                        s
-                    ),
-                })
-            }
-        }
-
-        let mut json_response: Value = res.json().unwrap();
-
-        self.access_token = match json_response["response"]["access_token"].take() {
-            Value::String(s) => s,
-            _ => panic!("Failed to get access token."),
-        };
-        self.refresh_token = match json_response["response"]["refresh_token"].take() {
-            Value::String(s) => s,
-            _ => panic!("Failed to get refresh token."),
-        };
-        Ok(())
-    }
-    /// Refreshes the authentication. You should use this when your access token is close to expiring.
-    pub fn refresh_auth(&mut self) -> Result<(), AuthError> {
-        let refresh_clone = self.refresh_token.clone();
-        let mut data = HashMap::new();
-
-        data.insert("client_id", CLIENT_ID);
-        data.insert("client_secret", CLIENT_SECRET);
-        data.insert("get_secure_url", "1");
-
-        data.insert("grant_type", "refresh_token");
-        data.insert("refresh_token", refresh_clone.as_str());
-
-        let mut res = self.send_auth_request(&data)
-            .expect("Error occured while requesting token.");
-
-        match res.status() {
-            StatusCode::OK | StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND => {
-                // success
-            }
-            s => {
-                return Err(AuthError {
-                    reason: format!("Login failed. Check your refresh token. Response: {:?}", s),
-                })
-            }
-        }
-
-        let mut json_response: Value = res.json().unwrap();
-
-        self.access_token = match json_response["response"]["access_token"].take() {
-            Value::String(s) => s,
-            _ => panic!("Failed to get access token."),
-        };
-        self.refresh_token = match json_response["response"]["refresh_token"].take() {
-            Value::String(s) => s,
-            _ => panic!("Failed to get refresh token."),
-        };
-        Ok(())
-    }
-    /// Get the access token.
-    #[inline]
-    pub fn access_token(&self) -> &String {
-        &self.access_token
-    }
-    /// Get a mutable reference to the access token.
-    #[inline]
-    pub fn access_token_mut(&mut self) -> &mut String {
-        &mut self.access_token
-    }
-    /// Get the refresh token.
-    #[inline]
-    pub fn refresh_token(&self) -> &String {
-        &self.refresh_token
-    }
-    /// Get a mutable reference to the refresh token.
-    #[inline]
-    pub fn refresh_token_mut(&mut self) -> &mut String {
-        &mut self.refresh_token
-    }
-    // private helper method
-    fn send_auth_request(&self, data: &HashMap<&str, &str>) -> Result<Response, reqwest::Error> {
-        self.client
-            .post("https://oauth.secure.pixiv.net/auth/token")
-            .form(&data)
-            .send()
-    }
-    /// Used to build a request to retrive `bad_words.json`.
-    /// # Request Transforms
-    /// None
-    pub fn bad_words(&self) -> PixivRequestBuilder {
-        let url = "https://public-api.secure.pixiv.net/v1.1/bad_words.json";
-        let url = Url::parse(&url).unwrap();
-        PixivRequestBuilder::new(
-            self,
-            Method::GET,
-            url,
-            HashMap::default(),
-        )
-    }
-    /// Used to build a request to retrieve information of a work.
-    /// # Request Transforms
-    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
-    /// * `include_stats` (default: `true`)
-    pub fn work(&self, illust_id: usize) -> PixivRequestBuilder {
-        let url = format!(
-            "https://public-api.secure.pixiv.net/v1/works/{}.json",
-            illust_id
-        );
-        let extra_params = [
-            ("image_sizes", "px_128x128,small,medium,large,px_480mw"),
-            ("include_stats", "true"),
-        ];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to retrieve information of a user.
-    /// # Request Transforms
-    /// * `profile_image_sizes` (default: `px_170x170,px_50x50`)
-    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
-    /// * `include_stats` (default: `true`)
-    pub fn user(&self, user_id: usize) -> PixivRequestBuilder {
-        let url = format!(
-            "https://public-api.secure.pixiv.net/v1/users/{}.json",
-            user_id
-        );
-        let extra_params = [
-            ("profile_image_sizes", "px_170x170,px_50x50"),
-            ("image_sizes", "px_128x128,small,medium,large,px_480mw"),
-            ("include_stats", "1"),
-            ("include_profile", "1"),
-            ("include_workspace", "1"),
-            ("include_contacts", "1"),
-        ];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to retrieve your account's feed.
-    /// # Request Transforms
-    /// * `show_r18` (default: `true`)
-    /// * `max_id`
-    pub fn feed(&self) -> PixivRequestBuilder {
-        let url = "https://public-api.secure.pixiv.net/v1/me/feeds.json";
-        let extra_params = [
-            ("relation", "all"),
-            ("type", "touch_nottext"),
-            ("show_r18", "1"),
-        ];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to retrieve works favorited on your account.
-    /// # Request Transforms
-    /// * `page` (default: `1`)
-    /// * `per_page` (default: `50`)
-    /// * `publicity` (default: `public`)
-    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
-    pub fn favorite_works(&self) -> PixivRequestBuilder {
-        let url = "https://public-api.secure.pixiv.net/v1/me/favorite_works.json";
-        let extra_params = [
-            ("page", "1"),
-            ("per_page", "50"),
-            ("publicity", "public"),
-            ("image_sizes", "px_128x128,px_480mw,large"),
-        ];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to favorite a work on your account.
-    /// # Request Transforms
-    /// * `publicity` (default: `public`)
-    pub fn favorite_work_add(&self, work_id: usize) -> PixivRequestBuilder {
-        let url = "https://public-api.secure.pixiv.net/v1/me/favorite_works.json";
-        let extra_params = [("publicity", "public")];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params
-            .iter()
-            .map(|&(k, v)| (k, v.into()))
-            .chain(Some(("work_id", work_id.to_string().into())))
-            .collect();
-        PixivRequestBuilder::new(
-            self,
-            Method::POST,
-            url,
-            params,
-        )
-    }
-    /// Used to build a request to remove favorited works on your account.
-    /// # Request Transforms
-    /// * `publicity` (default: `public`)
-    pub fn favorite_works_remove<B, I>(&self, work_ids: I) -> PixivRequestBuilder
-    where
-        B: Borrow<usize>,
-        I: IntoIterator<Item = B>,
-    {
-        let url = "https://public-api.secure.pixiv.net/v1/me/favorite_works.json";
-        let extra_params = [("publicity", "public")];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params
-            .iter()
-            .map(|&(k, v)| (k, v.into()))
-            .chain(Some(("ids", comma_delimited(work_ids).into())))
-            .collect();
-        PixivRequestBuilder::new(
-            self,
-            Method::DELETE,
-            url,
-            params,
-        )
-    }
-    /// Used to build a request to retrieve newest works from whoever you follow on your account.
-    /// # Request Transforms
-    /// * `page` (default: `1`)
-    /// * `per_page` (default: `30`)
-    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
-    /// * `include_stats` (default: `true`)
-    /// * `include_sanity_level` (default: `true`)
-    pub fn following_works(&self) -> PixivRequestBuilder {
-        let url = "https://public-api.secure.pixiv.net/v1/me/following/works.json";
-        let extra_params = [
-            ("page", "1"),
-            ("per_page", "30"),
-            ("image_sizes", "px_128x128,px480mw,large"),
-            ("include_stats", "true"),
-            ("include_sanity_level", "true"),
-        ];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to retrieve users you follow.
-    /// # Request Transforms
-    /// * `page` (default: `1`)
-    /// * `per_page` (default: `30`)
-    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
-    /// * `include_stats` (default: `true`)
-    /// * `include_sanity_level` (default: `true`)
-    pub fn following(&self) -> PixivRequestBuilder {
-        let url = "https://public-api.secure.pixiv.net/v1/me/following.json";
-        let extra_params = [("page", "1"), ("per_page", "30"), ("publicity", "public")];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to follow a user on your account.
-    /// # Request Transforms
-    /// * `publicity` (default: `public`)
-    pub fn following_add(&self, user_id: usize) -> PixivRequestBuilder {
-        let url = "https://public-api.secure.pixiv.net/v1/me/favorite-users.json";
-        let extra_params = [("publicity", "public")];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params
-            .iter()
-            .map(|&(k, v)| (k, v.into()))
-            .chain(Some(("target_user_id", user_id.to_string().into())))
-            .collect();
-        PixivRequestBuilder::new(
-            self,
-            Method::POST,
-            url,
-            params,
-        )
-    }
-    /// Used to build a request to unfollow users on your account.
-    /// # Request Transforms
-    /// * `publicity` (default: `public`)
-    pub fn following_remove<B, I>(&self, user_ids: I) -> PixivRequestBuilder
-    where
-        B: Borrow<usize>,
-        I: IntoIterator<Item = B>,
-    {
-        let url = "https://public-api.secure.pixiv.net/v1/me/favorite-users.json";
-        let extra_params = [("publicity", "public")];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params
-            .iter()
-            .map(|&(k, v)| (k, v.into()))
-            .chain(Some(("delete_ids", comma_delimited(user_ids).into())))
-            .collect();
-        PixivRequestBuilder::new(
-            self,
-            Method::DELETE,
-            url,
-            params,
-        )
-    }
-    /// Used to build a request to retrive a list of works submitted by a user.
-    /// # Request Transforms
-    /// * `page` (default: `1`)
-    /// * `per_page` (default: `30`)
-    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
-    /// * `include_stats` (default: `true`)
-    /// * `include_sanity_level` (default: `true`)
-    pub fn user_works(&self, user_id: usize) -> PixivRequestBuilder {
-        let url = format!(
-            "https://public-api.secure.pixiv.net/v1/users/{}/works.json",
-            user_id
-        );
-        let extra_params = [
-            ("page", "1"),
-            ("per_page", "30"),
-            ("image_sizes", "px_128x128,px480mw,large"),
-            ("include_stats", "true"),
-            ("include_sanity_level", "true"),
-        ];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to retrive a list of works favorited by a user.
-    /// # Request Transforms
-    /// * `page` (default: `1`)
-    /// * `per_page` (default: `30`)
-    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
-    /// * `include_sanity_level` (default: `true`)
-    pub fn user_favorite_works(&self, user_id: usize) -> PixivRequestBuilder {
-        let url = format!(
-            "https://public-api.secure.pixiv.net/v1/users/{}/favorite_works.json",
-            user_id
-        );
-        let extra_params = [
-            ("page", "1"),
-            ("per_page", "30"),
-            ("image_sizes", "px_128x128,px480mw,large"),
-            ("include_sanity_level", "true"),
-        ];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to retrive a user's feed.
-    /// # Request Transforms
-    /// * `show_r18` (default: `true`)
-    pub fn user_feed(&self, user_id: usize) -> PixivRequestBuilder {
-        let url = format!(
-            "https://public-api.secure.pixiv.net/v1/users/{}/feeds.json",
-            user_id
-        );
-        let extra_params = [
-            ("relation", "all"),
-            ("type", "touch_nottext"),
-            ("show_r18", "1"),
-        ];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to retrieve users a user follows.
-    /// # Request Transforms
-    /// * `page` (default: `1`)
-    /// * `per_page` (default: `30`)
-    /// * `max_id`
-    pub fn user_following(&self, user_id: usize) -> PixivRequestBuilder {
-        let url = format!(
-            "https://public-api.secure.pixiv.net/v1/users/{}/following.json",
-            user_id
-        );
-        let extra_params = [("page", "1"), ("per_page", "30")];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to retrieve a list of ranking posts.
-    /// # Request Transforms
-    /// * `ranking_mode` (default: `RankingMode::Daily`)
-    /// * `page` (default: `1`)
-    /// * `per_page` (default: `50`)
-    /// * `include_stats` (default: `true`)
-    /// * `include_sanity_level` (default: `true`)
-    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
-    /// * `profile_image_sizes` (default: `px_170x170,px_50x50`)
-    pub fn ranking(&self, ranking_type: RankingType) -> PixivRequestBuilder {
-        let url = format!(
-            "https://public-api.secure.pixiv.net/v1/ranking/{}.json",
-            ranking_type.as_str()
-        );
-        let extra_params = [
-            ("mode", "daily"),
-            ("page", "1"),
-            ("per_page", "50"),
-            ("include_stats", "True"),
-            ("include_sanity_level", "True"),
-            ("image_sizes", "px_128x128,small,medium,large,px_480mw"),
-            ("profile_image_sizes", "px_170x170,px_50x50"),
-        ];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to search for posts on a query.
-    /// # Request Transforms
-    /// * `page` (default: `1`)
-    /// * `per_page` (default: `30`)
-    /// * `date`
-    /// * `search_mode` (default: `SearchMode::Text`)
-    /// * `search_period` (default: `SearchPeriod::All`)
-    /// * `search_order` (default: `desc`)
-    /// * `search_sort` (default: `date`)
-    /// * `search_types` (default: `illustration,manga,ugoira`)
-    /// * `include_stats` (default: `true`)
-    /// * `include_sanity_level` (default: `true`)
-    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
-    pub fn search_works<'a, V>(&'a self, query: V) -> PixivRequestBuilder<'a>
-    where
-        Cow<'a, str>: From<V>,
-    {
-        let url = "https://public-api.secure.pixiv.net/v1/search/works.json";
-        let extra_params = [
-            ("page", "1"),
-            ("per_page", "30"),
-            ("mode", "text"),
-            ("period", "all"),
-            ("order", "desc"),
-            ("sort", "date"),
-            ("types", "illustration,manga,ugoira"),
-            ("include_stats", "true"),
-            ("include_sanity_level", "true"),
-            ("image_sizes", "px_128x128,px480mw,large"),
-        ];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params
-            .iter()
-            .map(|&(k, v)| (k, v.into()))
-            .chain(Some(("q", query.into())))
-            .collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Used to build a request to retrieve the latest submitted works by everyone.
-    /// # Request Transforms
-    /// * `page` (default: `1`)
-    /// * `per_page` (default: `50`)
-    /// * `date`
-    /// * `include_stats` (default: `true`)
-    /// * `include_sanity_level` (default: `true`)
-    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
-    /// * `profile_image_sizes` (default: `px_170x170,px_50x50`)
-    pub fn latest_works(&self) -> PixivRequestBuilder {
-        let url = "https://public-api.secure.pixiv.net/v1/works.json";
-        let extra_params = [
-            ("page", "1"),
-            ("per_page", "30"),
-            ("include_stats", "true"),
-            ("include_sanity_level", "true"),
-            ("image_sizes", "px_128x128,px480mw,large"),
-            ("profile_image_sizes", "px_170x170,px_50x50"),
-        ];
-        let url = Url::parse(&url).unwrap();
-        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
-        PixivRequestBuilder::new(self, Method::GET, url, params)
-    }
-    /// Executes a given `PixivRequest`.
-    pub fn execute(&self, request: PixivRequest) -> Result<Response, reqwest::Error> {
-        self.client.request(request.method,  request.url)
-                   .headers(request.headers)
-                   .bearer_auth(self.access_token.clone())
-                   .send()
-    }
-}
-
 impl PixivRequest {
     /// Create a new `PixivRequest`.
     /// A `PixivRequest` is returned when calling `build()` on `PixivRequestBuilder`, so it is recommended you use that instead.
     #[inline]
-    pub fn new(method: Method, url: Url, headers: HeaderMap) -> PixivRequest {
+    pub fn new(method: Method, url: Uri, headers: HeaderMap) -> PixivRequest {
         PixivRequest {
             method,
             url,
@@ -819,12 +318,12 @@ impl PixivRequest {
     }
     /// Get the url.
     #[inline]
-    pub fn url(&self) -> &Url {
+    pub fn url(&self) -> &Uri {
         &self.url
     }
     /// Get a mutable reference to the url.
     #[inline]
-    pub fn url_mut(&mut self) -> &Url {
+    pub fn url_mut(&mut self) -> &mut Uri {
         &mut self.url
     }
     /// Get the headers.
@@ -837,69 +336,77 @@ impl PixivRequest {
     pub fn headers_mut(&mut self) -> &mut HeaderMap {
         &mut self.headers
     }
-    fn extend_query_pairs<I, K, V>(&mut self, params: I)
-    where
-        I: IntoIterator,
-        I::Item: Borrow<(K, V)>,
-        K: AsRef<str>,
-        V: AsRef<str>,
-    {
-        self.url.query_pairs_mut().extend_pairs(params);
+
+    ///Sets query using `serde_urlencoded`
+    fn set_query_params<Q: serde::Serialize>(mut self, params: &Q) -> Self {
+        let mut uri_parts = self.url.into_parts();
+        let path = uri_parts.path_and_query;
+
+        let mut buffer = utils::BytesWriter::with_smol_capacity();
+        let query = serde_urlencoded::to_string(params).expect("To url-encode");
+
+        let _ = match path {
+            Some(path) => write!(buffer, "{}?{}", path.path(), query),
+            None => write!(buffer, "?{}", query),
+        };
+
+        uri_parts.path_and_query = Some(http::uri::PathAndQuery::from_shared(buffer.into_inner().freeze()).expect("To create path and query"));
+
+        self.url = match http::Uri::from_parts(uri_parts) {
+            Ok(uri) => uri,
+            Err(error) => panic!("Unable to set query for URI: {}", error)
+        };
+
+        self
     }
 }
 
 impl<'a> PixivRequestBuilder<'a> {
     /// Create a new `PixivRequestBuilder`.
     /// Functions in `Pixiv` expedite a lot of this for you, so using this directly isn't recommended unless you know what you want.
-    pub fn new(
-        pixiv: &'a Pixiv,
-        method: Method,
-        url: Url,
-        params: HashMap<&'a str, Cow<'a, str>>,
-    ) -> PixivRequestBuilder<'a> {
+    pub fn new(method: Method, url: Uri, params: HashMap<&'a str, Cow<'a, str>>) -> Self {
         // set headers
         let mut headers = HeaderMap::new();
         headers.insert(header::REFERER, header::HeaderValue::from_static("http://spapi.pixiv.net/"));
 
         PixivRequestBuilder {
-            pixiv,
             request: PixivRequest::new(method, url, headers),
             params,
         }
     }
     /// Sets the `page` param.
     #[inline]
-    pub fn page(self, value: usize) -> PixivRequestBuilder<'a> {
+    pub fn page(self, value: usize) -> Self {
         self.raw_param("page", value.to_string())
     }
     /// Sets the `per_page` param.
     #[inline]
-    pub fn per_page(self, value: usize) -> PixivRequestBuilder<'a> {
+    pub fn per_page(self, value: usize) -> Self {
         self.raw_param("value", value.to_string())
     }
     /// Sets the `max_id` param.
     #[inline]
-    pub fn max_id(self, value: usize) -> PixivRequestBuilder<'a> {
+    pub fn max_id(self, value: usize) -> Self {
         self.raw_param("max_id", value.to_string())
     }
     /// Sets the `image_sizes` param. Available types: `px_128x128`, `small`, `medium`, `large`, `px_480mw`
     #[inline]
-    pub fn image_sizes(self, values: &[&str]) -> PixivRequestBuilder<'a> {
+    pub fn image_sizes(self, values: &[&str]) -> Self {
         self.raw_param("image_sizes", comma_delimited::<&str, _, _>(values))
     }
     /// Sets the `profile_image_sizes` param. Available types: `px_170x170,px_50x50`
     #[inline]
-    pub fn profile_image_sizes(self, values: &[&str]) -> PixivRequestBuilder<'a> {
+    pub fn profile_image_sizes(self, values: &[&str]) -> Self {
         self.raw_param("profile_image_sizes", comma_delimited::<&str, _, _>(values))
     }
     /// Sets the `publicity` param. Must be a value of enum `Publicity`.
     #[inline]
-    pub fn publicity(self, value: Publicity) -> PixivRequestBuilder<'a> {
+    pub fn publicity(self, value: Publicity) -> Self {
         self.raw_param("publicity", value.as_str())
     }
     /// Sets the `show_r18` param. `true` means R-18 works will be included.
     #[inline]
-    pub fn show_r18(self, value: bool) -> PixivRequestBuilder<'a> {
+    pub fn show_r18(self, value: bool) -> Self {
         if value {
             self.raw_param("show_r18", "1")
         } else {
@@ -908,7 +415,7 @@ impl<'a> PixivRequestBuilder<'a> {
     }
     /// Sets the `include_stats` param.
     #[inline]
-    pub fn include_stats(self, value: bool) -> PixivRequestBuilder<'a> {
+    pub fn include_stats(self, value: bool) -> Self {
         if value {
             self.raw_param("include_stats", "true")
         } else {
@@ -917,7 +424,7 @@ impl<'a> PixivRequestBuilder<'a> {
     }
     /// Sets the `include_sanity_level` param.
     #[inline]
-    pub fn include_sanity_level(self, value: bool) -> PixivRequestBuilder<'a> {
+    pub fn include_sanity_level(self, value: bool) -> Self {
         if value {
             self.raw_param("include_sanity_level", "true")
         } else {
@@ -926,11 +433,11 @@ impl<'a> PixivRequestBuilder<'a> {
     }
     /// Sets the ranking mode in the case of a `ranking()` call. Must be a value of enum `RankingMode`.
     #[inline]
-    pub fn ranking_mode(self, value: RankingMode) -> PixivRequestBuilder<'a> {
+    pub fn ranking_mode(self, value: RankingMode) -> Self {
         self.raw_param("mode", value.as_str())
     }
     /// Sets the `date` param. Must be a valid date in the form of `%Y-%m-%d`, e.g. `2018-2-22`.
-    pub fn date<V>(self, value: V) -> PixivRequestBuilder<'a>
+    pub fn date<V>(self, value: V) -> Self
     where
         Cow<'a, str>: From<V>,
     {
@@ -941,21 +448,21 @@ impl<'a> PixivRequestBuilder<'a> {
     }
     /// Sets the `period` param in the case of a `search_works()` call. Must be a value of enum `SearchPeriod`.
     #[inline]
-    pub fn search_period(self, value: SearchPeriod) -> PixivRequestBuilder<'a> {
+    pub fn search_period(self, value: SearchPeriod) -> Self {
         self.raw_param("period", value.as_str())
     }
     /// Sets the `mode` param in the case of a `search_works()` call. Must be a value of enum `SearchMode`.
     #[inline]
-    pub fn search_mode(self, value: SearchMode) -> PixivRequestBuilder<'a> {
+    pub fn search_mode(self, value: SearchMode) -> Self {
         self.raw_param("mode", value.as_str())
     }
     /// Sets the `order` param in the case of a `search_works()` call. Must be a value of enum `SearchOrder`.
     #[inline]
-    pub fn search_order(self, value: SearchOrder) -> PixivRequestBuilder<'a> {
+    pub fn search_order(self, value: SearchOrder) -> Self {
         self.raw_param("order", value.as_str())
     }
     /// Sets the `sort` param in the case of a `search_works()` call. Not sure if there's any variations here, but this function is included for convenience.
-    pub fn search_sort<V>(self, value: V) -> PixivRequestBuilder<'a>
+    pub fn search_sort<V>(self, value: V) -> Self
     where
         Cow<'a, str>: From<V>,
     {
@@ -963,217 +470,398 @@ impl<'a> PixivRequestBuilder<'a> {
     }
     /// Sets the `types` param in the case of a `search_works()` call. Available values: `illustration`, `manga`, `ugoira`.
     #[inline]
-    pub fn search_types(self, values: &[&str]) -> PixivRequestBuilder<'a> {
+    pub fn search_types(self, values: &[&str]) -> Self {
         self.raw_param("types", comma_delimited::<&str, _, _>(values))
     }
-    fn raw_param<V>(mut self, key: &'a str, value: V) -> PixivRequestBuilder<'a>
+    fn raw_param<V>(mut self, key: &'a str, value: V) -> Self
     where
         Cow<'a, str>: From<V>,
     {
         self.params.insert(key, value.into());
         self
     }
+
+    /// Used to build a request to retrive `bad_words.json`.
+    /// # Request Transforms
+    /// None
+    pub fn bad_words() -> Self {
+        const API_URL: &'static str = "https://public-api.secure.pixiv.net/v1.1/bad_words.json";
+        let url = Uri::from_static(API_URL);
+        PixivRequestBuilder::new(
+            Method::GET,
+            url,
+            HashMap::default(),
+        )
+    }
+    /// Used to build a request to retrieve information of a work.
+    /// # Request Transforms
+    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
+    /// * `include_stats` (default: `true`)
+    pub fn work(illust_id: usize) -> Self {
+        let url = format!(
+            "https://public-api.secure.pixiv.net/v1/works/{}.json",
+            illust_id
+        );
+        let extra_params = [
+            ("image_sizes", "px_128x128,small,medium,large,px_480mw"),
+            ("include_stats", "true"),
+        ];
+        let url = Uri::try_from(url).unwrap();
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+    /// Used to build a request to retrieve information of a user.
+    /// # Request Transforms
+    /// * `profile_image_sizes` (default: `px_170x170,px_50x50`)
+    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
+    /// * `include_stats` (default: `true`)
+    pub fn user(user_id: usize) -> Self {
+        let url = format!(
+            "https://public-api.secure.pixiv.net/v1/users/{}.json",
+            user_id
+        );
+        let extra_params = [
+            ("profile_image_sizes", "px_170x170,px_50x50"),
+            ("image_sizes", "px_128x128,small,medium,large,px_480mw"),
+            ("include_stats", "1"),
+            ("include_profile", "1"),
+            ("include_workspace", "1"),
+            ("include_contacts", "1"),
+        ];
+        let url = Uri::try_from(&url).unwrap();
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+    /// Used to build a request to retrieve your account's feed.
+    /// # Request Transforms
+    /// * `show_r18` (default: `true`)
+    /// * `max_id`
+    pub fn feed() -> Self {
+        const API_URL: &'static str = "https://public-api.secure.pixiv.net/v1/me/feeds.json";
+        let url = Uri::from_static(API_URL);
+
+        let extra_params = [
+            ("relation", "all"),
+            ("type", "touch_nottext"),
+            ("show_r18", "1"),
+        ];
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+    /// Used to build a request to retrieve works favorited on your account.
+    /// # Request Transforms
+    /// * `page` (default: `1`)
+    /// * `per_page` (default: `50`)
+    /// * `publicity` (default: `public`)
+    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
+    pub fn favorite_works() -> Self {
+        const API_URL: &'static str = "https://public-api.secure.pixiv.net/v1/me/favorite_works.json";
+        let url = Uri::from_static(API_URL);
+
+        let extra_params = [
+            ("page", "1"),
+            ("per_page", "50"),
+            ("publicity", "public"),
+            ("image_sizes", "px_128x128,px_480mw,large"),
+        ];
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+    /// Used to build a request to favorite a work on your account.
+    /// # Request Transforms
+    /// * `publicity` (default: `public`)
+    pub fn favorite_work_add(work_id: usize) -> Self {
+        const API_URL: &'static str = "https://public-api.secure.pixiv.net/v1/me/favorite_works.json";
+        let url = Uri::from_static(API_URL);
+
+        let extra_params = [("publicity", "public")];
+        let params = extra_params
+            .iter()
+            .map(|&(k, v)| (k, v.into()))
+            .chain(Some(("work_id", work_id.to_string().into())))
+            .collect();
+        PixivRequestBuilder::new(Method::POST, url, params)
+    }
+    /// Used to build a request to remove favorited works on your account.
+    /// # Request Transforms
+    /// * `publicity` (default: `public`)
+    pub fn favorite_works_remove<B, I>(work_ids: I) -> Self
+    where
+        B: Borrow<usize>,
+        I: IntoIterator<Item = B>,
+    {
+        const API_URL: &'static str = "https://public-api.secure.pixiv.net/v1/me/favorite_works.json";
+        let url = Uri::from_static(API_URL);
+
+        let extra_params = [("publicity", "public")];
+        let params = extra_params
+            .iter()
+            .map(|&(k, v)| (k, v.into()))
+            .chain(Some(("ids", comma_delimited(work_ids).into())))
+            .collect();
+        PixivRequestBuilder::new(Method::DELETE, url, params)
+    }
+    /// Used to build a request to retrieve newest works from whoever you follow on your account.
+    /// # Request Transforms
+    /// * `page` (default: `1`)
+    /// * `per_page` (default: `30`)
+    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
+    /// * `include_stats` (default: `true`)
+    /// * `include_sanity_level` (default: `true`)
+    pub fn following_works() -> Self {
+        const API_URL: &'static str = "https://public-api.secure.pixiv.net/v1/me/following/works.json";
+        let url = Uri::from_static(API_URL);
+
+        let extra_params = [
+            ("page", "1"),
+            ("per_page", "30"),
+            ("image_sizes", "px_128x128,px480mw,large"),
+            ("include_stats", "true"),
+            ("include_sanity_level", "true"),
+        ];
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+    /// Used to build a request to retrieve users you follow.
+    /// # Request Transforms
+    /// * `page` (default: `1`)
+    /// * `per_page` (default: `30`)
+    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
+    /// * `include_stats` (default: `true`)
+    /// * `include_sanity_level` (default: `true`)
+    pub fn following() -> Self {
+        const API_URL: &'static str = "https://public-api.secure.pixiv.net/v1/me/following.json";
+        let url = Uri::from_static(API_URL);
+
+        let extra_params = [("page", "1"), ("per_page", "30"), ("publicity", "public")];
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+    /// Used to build a request to follow a user on your account.
+    /// # Request Transforms
+    /// * `publicity` (default: `public`)
+    pub fn following_add(user_id: usize) -> Self {
+        const API_URL: &'static str = "https://public-api.secure.pixiv.net/v1/me/favorite-users.json";
+        let url = Uri::from_static(API_URL);
+
+        let extra_params = [("publicity", "public")];
+        let params = extra_params
+            .iter()
+            .map(|&(k, v)| (k, v.into()))
+            .chain(Some(("target_user_id", user_id.to_string().into())))
+            .collect();
+        PixivRequestBuilder::new(Method::POST, url, params)
+    }
+    /// Used to build a request to unfollow users on your account.
+    /// # Request Transforms
+    /// * `publicity` (default: `public`)
+    pub fn following_remove<B, I>(user_ids: I) -> Self
+    where
+        B: Borrow<usize>,
+        I: IntoIterator<Item = B>,
+    {
+        const API_URL: &'static str = "https://public-api.secure.pixiv.net/v1/me/favorite-users.json";
+        let url = Uri::from_static(API_URL);
+
+        let extra_params = [("publicity", "public")];
+        let params = extra_params
+            .iter()
+            .map(|&(k, v)| (k, v.into()))
+            .chain(Some(("delete_ids", comma_delimited(user_ids).into())))
+            .collect();
+        PixivRequestBuilder::new(Method::DELETE, url, params)
+    }
+    /// Used to build a request to retrive a list of works submitted by a user.
+    /// # Request Transforms
+    /// * `page` (default: `1`)
+    /// * `per_page` (default: `30`)
+    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
+    /// * `include_stats` (default: `true`)
+    /// * `include_sanity_level` (default: `true`)
+    pub fn user_works(user_id: usize) -> Self {
+        let url = format!(
+            "https://public-api.secure.pixiv.net/v1/users/{}/works.json",
+            user_id
+        );
+        let extra_params = [
+            ("page", "1"),
+            ("per_page", "30"),
+            ("image_sizes", "px_128x128,px480mw,large"),
+            ("include_stats", "true"),
+            ("include_sanity_level", "true"),
+        ];
+        let url = Uri::try_from(&url).unwrap();
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+    /// Used to build a request to retrive a list of works favorited by a user.
+    /// # Request Transforms
+    /// * `page` (default: `1`)
+    /// * `per_page` (default: `30`)
+    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
+    /// * `include_sanity_level` (default: `true`)
+    pub fn user_favorite_works(user_id: usize) -> Self {
+        let url = format!(
+            "https://public-api.secure.pixiv.net/v1/users/{}/favorite_works.json",
+            user_id
+        );
+        let extra_params = [
+            ("page", "1"),
+            ("per_page", "30"),
+            ("image_sizes", "px_128x128,px480mw,large"),
+            ("include_sanity_level", "true"),
+        ];
+        let url = Uri::try_from(&url).unwrap();
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+    /// Used to build a request to retrive a user's feed.
+    /// # Request Transforms
+    /// * `show_r18` (default: `true`)
+    pub fn user_feed(user_id: usize) -> Self {
+        let url = format!(
+            "https://public-api.secure.pixiv.net/v1/users/{}/feeds.json",
+            user_id
+        );
+        let extra_params = [
+            ("relation", "all"),
+            ("type", "touch_nottext"),
+            ("show_r18", "1"),
+        ];
+        let url = Uri::try_from(&url).unwrap();
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+    /// Used to build a request to retrieve users a user follows.
+    /// # Request Transforms
+    /// * `page` (default: `1`)
+    /// * `per_page` (default: `30`)
+    /// * `max_id`
+    pub fn user_following(user_id: usize) -> Self {
+        let url = format!(
+            "https://public-api.secure.pixiv.net/v1/users/{}/following.json",
+            user_id
+        );
+        let extra_params = [("page", "1"), ("per_page", "30")];
+        let url = Uri::try_from(&url).unwrap();
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+    /// Used to build a request to retrieve a list of ranking posts.
+    /// # Request Transforms
+    /// * `ranking_mode` (default: `RankingMode::Daily`)
+    /// * `page` (default: `1`)
+    /// * `per_page` (default: `50`)
+    /// * `include_stats` (default: `true`)
+    /// * `include_sanity_level` (default: `true`)
+    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
+    /// * `profile_image_sizes` (default: `px_170x170,px_50x50`)
+    pub fn ranking(ranking_type: RankingType) -> Self {
+        let url = format!(
+            "https://public-api.secure.pixiv.net/v1/ranking/{}.json",
+            ranking_type.as_str()
+        );
+        let extra_params = [
+            ("mode", "daily"),
+            ("page", "1"),
+            ("per_page", "50"),
+            ("include_stats", "True"),
+            ("include_sanity_level", "True"),
+            ("image_sizes", "px_128x128,small,medium,large,px_480mw"),
+            ("profile_image_sizes", "px_170x170,px_50x50"),
+        ];
+        let url = Uri::try_from(&url).unwrap();
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+    /// Used to build a request to search for posts on a query.
+    /// # Request Transforms
+    /// * `page` (default: `1`)
+    /// * `per_page` (default: `30`)
+    /// * `date`
+    /// * `search_mode` (default: `SearchMode::Text`)
+    /// * `search_period` (default: `SearchPeriod::All`)
+    /// * `search_order` (default: `desc`)
+    /// * `search_sort` (default: `date`)
+    /// * `search_types` (default: `illustration,manga,ugoira`)
+    /// * `include_stats` (default: `true`)
+    /// * `include_sanity_level` (default: `true`)
+    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
+    pub fn search_works<V>(query: V) -> PixivRequestBuilder<'a>
+    where
+        Cow<'a, str>: From<V>,
+    {
+        const API_URL: &'static str = "https://public-api.secure.pixiv.net/v1/search/works.json";
+        let url = Uri::from_static(API_URL);
+
+        let extra_params = [
+            ("page", "1"),
+            ("per_page", "30"),
+            ("mode", "text"),
+            ("period", "all"),
+            ("order", "desc"),
+            ("sort", "date"),
+            ("types", "illustration,manga,ugoira"),
+            ("include_stats", "true"),
+            ("include_sanity_level", "true"),
+            ("image_sizes", "px_128x128,px480mw,large"),
+        ];
+        let params = extra_params
+            .iter()
+            .map(|&(k, v)| (k, v.into()))
+            .chain(Some(("q", query.into())))
+            .collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
+
+    /// Used to build a request to retrieve the latest submitted works by everyone.
+    /// # Request Transforms
+    /// * `page` (default: `1`)
+    /// * `per_page` (default: `50`)
+    /// * `date`
+    /// * `include_stats` (default: `true`)
+    /// * `include_sanity_level` (default: `true`)
+    /// * `image_sizes` (default: `px_128x128,small,medium,large,px_480mw`)
+    /// * `profile_image_sizes` (default: `px_170x170,px_50x50`)
+    pub fn latest_works() -> Self {
+        const API_URL: &'static str = "https://public-api.secure.pixiv.net/v1/works.json";
+        let url = Uri::from_static(API_URL);
+
+        let extra_params = [
+            ("page", "1"),
+            ("per_page", "30"),
+            ("include_stats", "true"),
+            ("include_sanity_level", "true"),
+            ("image_sizes", "px_128x128,px480mw,large"),
+            ("profile_image_sizes", "px_170x170,px_50x50"),
+        ];
+        let params = extra_params.iter().map(|&(k, v)| (k, v.into())).collect();
+        PixivRequestBuilder::new(Method::GET, url, params)
+    }
     /// Returns a `PixivRequest` which can be inspected and/or executed with `Pixiv::execute()`.
     #[inline]
-    pub fn build(mut self) -> PixivRequest {
-        self.request.extend_query_pairs(&self.params);
-        self.request
+    pub fn build(self) -> PixivRequest {
+        self.request.set_query_params(&self.params)
     }
-    /// Sends the request. This function consumes `self`.
-    pub fn send(self) -> Result<Response, reqwest::Error> {
-        let pixiv = self.pixiv;
-        let req = self.build();
-        trace!("Request URL: {}", req.url);
-        pixiv.execute(req)
-    }
-}
-
-fn comma_delimited<T, B, I>(iter: I) -> String
-where
-    T: fmt::Display + ?Sized,
-    B: Borrow<T>,
-    I: IntoIterator<Item = B>,
-{
-    let mut iter = iter.into_iter();
-    let mut ret = String::new();
-    if let Some(b) = iter.next() {
-        write!(ret, "{}", b.borrow()).unwrap();
-        for b in iter {
-            write!(ret, ",{}", b.borrow()).unwrap();
-        }
-    }
-    ret
 }
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
-
-    #[test]
-    fn test_login() {
-        let client = Client::new();
-
-        let mut pixiv: Pixiv = Pixiv::new(&client);
-
-        kankyo::load().unwrap();
-
-        pixiv
-            .login(
-                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
-                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
-            )
-            .expect("Failed to log in.");
-    }
-
-    #[test]
-    fn test_refresh_auth() {
-        let client = Client::new();
-
-        let mut pixiv: Pixiv = Pixiv::new(&client);
-
-        kankyo::load().unwrap();
-
-        pixiv
-            .login(
-                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
-                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
-            )
-            .expect("Failed to log in.");
-
-        pixiv
-            .refresh_auth()
-            .expect("Failed to refresh access token");
-    }
-
-    #[test]
-    fn test_bad_words() {
-        let client = Client::new();
-
-        let mut pixiv: Pixiv = Pixiv::new(&client);
-
-        kankyo::load().unwrap();
-
-        pixiv
-            .login(
-                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
-                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
-            )
-            .expect("Failed to log in.");
-
-        let bad_words: Value = pixiv
-            .bad_words()
-            .send()
-            .expect("Request failed.")
-            .json()
-            .expect("Failed to parse as json.");
-
-        println!("{}", bad_words);
-    }
-
-    #[test]
-    fn test_work() {
-        let client = Client::new();
-
-        let mut pixiv: Pixiv = Pixiv::new(&client);
-
-        kankyo::load().unwrap();
-
-        pixiv
-            .login(
-                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
-                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
-            )
-            .expect("Failed to log in.");
-
-        let work: Value = pixiv
-            .work(66024340)
-            .send()
-            .expect("Request failed.")
-            .json()
-            .expect("Failed to parse as json.");
-
-        println!("{}", work);
-    }
-
-    #[test]
-    fn test_user() {
-        let client = Client::new();
-
-        let mut pixiv: Pixiv = Pixiv::new(&client);
-
-        kankyo::load().unwrap();
-
-        pixiv
-            .login(
-                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
-                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
-            )
-            .expect("Failed to log in.");
-
-        let following_works: Value = pixiv
-            .user(6996493)
-            .send()
-            .expect("Request failed.")
-            .json()
-            .expect("Failed to parse as json.");
-
-        println!("{}", following_works);
-    }
-
-    #[test]
-    fn test_following_works() {
-        let client = Client::new();
-
-        let mut pixiv: Pixiv = Pixiv::new(&client);
-
-        kankyo::load().unwrap();
-
-        pixiv
-            .login(
-                &kankyo::key("PIXIV_ID").expect("PIXIV_ID isn't set!"),
-                &kankyo::key("PIXIV_PW").expect("PIXIV_PW isn't set!"),
-            )
-            .expect("Failed to log in.");
-
-        let following_works: Value = pixiv
-            .following_works()
-            .image_sizes(&["large"])
-            .include_sanity_level(false)
-            .send()
-            .expect("Request failed.")
-            .json()
-            .expect("Failed to parse as json.");
-
-        println!("{}", following_works);
-    }
 
     // Test that generic method calls compile properly.
     #[test]
     fn test_into_iterator() {
-        let client = Client::new();
-        let pixiv = Pixiv::new(&client);
-
         let slice: &[usize] = &[0, 1, 2];
         let vec = slice.to_owned();
         let iter = vec.clone().into_iter().chain(Some(3));
 
-        pixiv.favorite_works_remove(slice);
-        pixiv.favorite_works_remove(vec.clone());
-        pixiv.favorite_works_remove(iter.clone());
+        PixivRequestBuilder::favorite_works_remove(slice);
+        PixivRequestBuilder::favorite_works_remove(vec.clone());
+        PixivRequestBuilder::favorite_works_remove(iter.clone());
 
-        pixiv.following_remove(slice);
-        pixiv.following_remove(vec);
-        pixiv.following_remove(iter);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_login_fail() {
-        let client = Client::new();
-
-        let mut pixiv: Pixiv = Pixiv::new(&client);
-
-        pixiv.login("", "").expect("Failed to log in.");
+        PixivRequestBuilder::following_remove(slice);
+        PixivRequestBuilder::following_remove(vec);
+        PixivRequestBuilder::following_remove(iter);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,86 @@
+use ::bytes;
+
+use ::std::fmt::{Write, Display};
+use ::std::borrow::Borrow;
+use ::std::io;
+
+pub fn comma_delimited<T: Display + ?Sized, B: Borrow<T>, I: IntoIterator<Item=B>>(iter: I) -> String {
+    let mut iter = iter.into_iter();
+    let mut ret = String::new();
+    if let Some(b) = iter.next() {
+        write!(ret, "{}", b.borrow()).unwrap();
+        for b in iter {
+            write!(ret, ",{}", b.borrow()).unwrap();
+        }
+    }
+    ret
+}
+
+//const DEFAULT_CAPACITY: usize = 4096;
+const SMOL_CAPCITY: usize = 64;
+
+pub(crate) struct BytesWriter {
+    buf: bytes::BytesMut,
+}
+
+impl BytesWriter {
+    //#[inline]
+    //pub fn new() -> Self {
+    //    Self::with_capacity(DEFAULT_CAPACITY)
+    //}
+
+    #[inline]
+    pub fn with_smol_capacity() -> Self {
+        Self::with_capacity(SMOL_CAPCITY)
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            buf: bytes::BytesMut::with_capacity(capacity)
+        }
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> bytes::BytesMut {
+        self.buf
+    }
+
+    //#[inline]
+    //pub fn freeze(&mut self) -> bytes::Bytes {
+    //    mem::replace(&mut self.buf, bytes::BytesMut::new()).freeze()
+    //}
+
+    //#[inline]
+    //pub fn len(&self) -> usize {
+    //    self.buf.len()
+    //}
+
+    //#[inline]
+    //pub fn split_off(&mut self, at: usize) -> Self {
+    //    Self {
+    //        buf: self.buf.split_off(at)
+    //    }
+    //}
+
+    //#[inline]
+    //pub fn reserve(&mut self, add: usize) {
+    //    self.buf.reserve(add);
+    //}
+}
+
+impl io::Write for BytesWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.buf.extend_from_slice(buf);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Now PR is ready.
As per our discussion I replaced `reqwest::Url` with `http::uri::Uri`

I took liberty to copy-paste some useful code from my code base for `bytes`
I commented unused code for now, but I believe in future there might be need, if you'd like to have effective way to construct `http` primitives

New feature is added `reqwest-client`

This feature is enabled by default and provides pixiv client based on reqwest.

`serde_urlencoded` is added as dependency for convenient way to set query params to Uri(it is the same crate that is used by `reqwest` I believe)
`bytes` is added for effective way to construct new `Uri` when setting query params

P.s. for convenience rebase I squashed all changes into single commit so sorry for single big commit
P.s.s If you'd like to discuss something real quick you can also ping me over discord(I'm in serenity channel) or irc (I go by `Douman` there)

Closes #8
